### PR TITLE
Logging README

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,18 @@
 
 <body>
   Piels
+  <script>
+    var xhr = new XMLHttpRequest();
+
+    xhr.onreadystatechange = function() {
+        if (this.readyState == 4 && this.status == 200) {
+            console.log(this.responseText);
+        }
+    }
+
+    xhr.open("GET", "README.md", true);
+    xhr.send();
+  </script>
 </body>
 
 </html>


### PR DESCRIPTION
Testing that GitHub hosting allows reading external files (cross-origin problem).
On local machine problem solved with `python -m SimpleHTTPServer` at the project root and then go to `http://localhost:8000/` in browser.
